### PR TITLE
Changes to support Elasticsearch 1.0.0.Beta2 - Also works with 1.0.0.RC1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/target/
 *.idea
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
 		<dependency>
 			<groupId>org.elasticsearch</groupId>
 			<artifactId>elasticsearch</artifactId>
-			<version>0.19.8</version>
+			<version>1.0.0.Beta2</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -161,6 +161,13 @@
 					<includeAttached>true</includeAttached>
 				</configuration>
 			</plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.4</version>
+            </plugin>
+
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
## pom.xml updates:
- Update Elasticsearch version in dependency section.
- Add jar generation to target and support the plugin --install command.
## pom.xml updates:
- Include splitIndex missing method.
